### PR TITLE
Add sidebar bullets

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1,0 +1,13 @@
+.VPSidebarItem.level-1 .VPLink::before {
+  border: 3px solid transparent;
+  border-left: 4px solid var(--vp-c-text-2);
+  border-right: none;
+  content: "";
+  left: -10px;
+  position: absolute;
+  top: 13px;
+}
+
+.VPSidebarItem.level-1.is-active .VPLink::before {
+  border-left-color: var(--vp-c-brand);
+}

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,0 +1,4 @@
+import DefaultTheme from 'vitepress/theme'
+import './custom.css'
+
+export default DefaultTheme


### PR DESCRIPTION
As the page titles are questions, they tend to span multiple lines in the sidebar. This makes the sidebar quite difficult to read.

This PR adds small triangular bullets next to each question, to try to make it clearer where each questions starts.