### PR TITLE
Add vitepress-plugin-group-icons

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,4 +1,5 @@
 import { defineConfig } from 'vitepress'
+import { groupIconMdPlugin, groupIconVitePlugin } from 'vitepress-plugin-group-icons'
 
 export default defineConfig({
   title: 'Vue Land FAQ',
@@ -19,6 +20,23 @@ export default defineConfig({
 
       return [['link', { rel: 'canonical', href: canonicalUrl }]]
     }
+  },
+
+  markdown: {
+    config(md) {
+      md.use(groupIconMdPlugin)
+    },
+  },
+
+  vite: {
+    plugins: [
+      groupIconVitePlugin({
+        customIcon: {
+          '.vue': 'vscode-icons:file-type-vue',
+          'vue': 'vscode-icons:file-type-js'
+        }
+      })
+    ],
   },
 
   themeConfig: {

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -47,6 +47,12 @@ html:not(.dark) {
   border-top: 0 none;
 }
 
+.vp-code-block-title-bar {
+  border: 1px solid var(--vue-land-code-block-border);
+  border-bottom: 0 none;
+  box-shadow: none;
+}
+
 /* Inline code in a custom block looks too much like a link */
 .custom-block.info code, .custom-block.tip code {
   color: var(--vp-code-color);

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,4 +1,5 @@
 import DefaultTheme from 'vitepress/theme'
+import 'virtual:group-icons.css'
 import './custom.css'
 
 export default DefaultTheme

--- a/docs/faq/accessing-the-route.md
+++ b/docs/faq/accessing-the-route.md
@@ -58,8 +58,7 @@ It is still possible to access `useRoute()` or `this.$route` during that initial
 
 Consider the following example. It tries to use the current route in `App.vue` to decide which layout to wrap around the `RouterView`:
 
-```vue
-<!-- App.vue -->
+```vue [App.vue]
 <script setup>
 import DefaultLayout from './layouts/DefaultLayout.vue'
 </script>
@@ -79,10 +78,7 @@ There are a few ways we might fix this problem.
 
 Vue Router provides the method [`isReady()`](https://router.vuejs.org/api/interfaces/Router.html#isReady), which can be used to wait until it has resolved the route. We could use it to defer mounting the application until the route is ready:
 
-```js
-// main.js or main.ts
-// ...
-
+```js [main.js]
 const app = createApp(App)
 
 app.use(router)
@@ -102,8 +98,7 @@ Depending on your application, that might not matter. A brief pause before the p
 
 With a bit of extra effort, we could show a loading indicator if the route isn't resolved yet. There are a few ways we might implement this. One approach would be to use `router.isReady()` inside `App.vue` to track when the router is ready. e.g.:
 
-```vue
-<!-- App.vue -->
+```vue [App.vue]
 <script setup>
 import { shallowRef } from 'vue'
 import { useRouter } from 'vue-router'
@@ -128,8 +123,7 @@ Here we're using the `LoadingIndicator` component in place of the layout. The `L
 
 We could also implement this using the slot of `RouterView`:
 
-```vue
-<!-- App.vue -->
+```vue [App.vue]
 <script setup>
 import DefaultLayout from './layouts/DefaultLayout.vue'
 import LoadingIndicator from './components/LoadingIndicator.vue'

--- a/docs/faq/blank-page-in-production.md
+++ b/docs/faq/blank-page-in-production.md
@@ -121,7 +121,7 @@ Usually it's fairly obvious when this is happening, as the rest of the page rend
 
 However, it can be tricky to tell whether routing is the problem if `App.vue` doesn't contain anything else. For example, imagine that `App.vue` just contains this:
 
-```vue
+```vue [App.vue]
 <template>
   <RouterView />
 </template>
@@ -131,7 +131,7 @@ As `App.vue` only renders `<RouterView />`, we can't easily tell whether the pro
 
 To help isolate the source of the problem, it is worth adding some extra temporary code to `App.vue`, to confirm that it is rendering correctly. For example:
 
-```vue
+```vue [App.vue]
 <template>
   <h1>Hello world!</h1>
   <RouterView />

--- a/docs/faq/no-active-pinia.md
+++ b/docs/faq/no-active-pinia.md
@@ -189,15 +189,13 @@ The error is shown when step 3 occurs before step 2. The Pinia instance must be 
 
 But, in practice, it probably isn't that simple. In a real application, those 3 steps usually don't sit in the same file. More likely, they're in 3 separate files, something like this:
 
-```js
-// useProductsStore.js
+```js [useProductsStore.js]
 export const useProductsStore = defineStore('products', {
   // ...
 })
 ```
 
-```js
-// main.js
+```js [main.js]
 import { createApp } from 'vue'
 import { createPinia } from 'pinia'
 import App from 'App.vue'
@@ -221,15 +219,13 @@ To understand that, we first need to understand `import`, and specifically how J
 
 Let's start with a plain `.js` example. It works much the same way with `.ts` and we'll stick to `.js` throughout this page. It's a bit more complicated with `.vue` files, but we'll cover those later.
 
-```js
-// main.js
+```js [main.js]
 import { data } from './store.js'
 
 console.log('main.js', data)
 ```
 
-```js
-// store.js
+```js [store.js]
 const data = { name: 'Vue' }
 
 console.log('store.js', data)
@@ -382,8 +378,7 @@ Generally speaking, you shouldn't be trying to access the store in top-level cod
 
 Let's say we have some code like this:
 
-```js
-// product-utils.js
+```js [product-utils.js]
 import { useProductsStore } from '@/stores/products'
 
 const products = useProductsStore()
@@ -401,8 +396,7 @@ When exactly this happens will depend on exactly where this file is imported. If
 
 In the example above, we might fix it by moving the call to `useProductsStore()` inside `fetchProduct()`:
 
-```js
-// product-utils.js
+```js [product-utils.js]
 import { useProductsStore } from '@/stores/products'
 
 export function fetchProduct(id) {
@@ -572,8 +566,7 @@ This can cause a lot of confusion, as top-level code can appear to work in some 
 
 Let's revisit an example we saw earlier:
 
-```js
-// product-utils.js
+```js [product-utils.js]
 import { useProductsStore } from '@/stores/products'
 
 const products = useProductsStore()
@@ -607,7 +600,7 @@ The Pinia instance will be created when the page first loads. If you edit one of
 
 Let's imagine we have code like this in our `main.js`:
 
-```js
+```js [main.js]
 import { createApp } from 'vue'
 import { createPinia } from 'pinia'
 import App from './App.vue'
@@ -630,7 +623,7 @@ Yes, we can. This almost certainly isn't a good idea, but it can work.
 
 For example, let's move some of the code above into a file called `app-create.js`:
 
-```js
+```js [app-create.js]
 import { createApp } from 'vue'
 import { createPinia } from 'pinia'
 import App from './App.vue'
@@ -643,7 +636,7 @@ export { app }
 
 Then, we could change our `main.js` to this:
 
-```js
+```js [main.js]
 import { app } from './app-create'
 import router from './router'
 
@@ -664,8 +657,7 @@ In the case of Pinia, it aims to be global in the same way that [`app.config.glo
 
 Let's imagine you choose not to use Pinia and instead do something like this:
 
-```js
-// store.js
+```js [store.js]
 import { reactive } from 'vue'
 
 export const state = reactive({})
@@ -731,7 +723,7 @@ import { loadProducts } from './products'
 
 So far, no store. Now let's take a look at `products.js`:
 
-```js
+```js [products.js]
 import { useProductsStore } from '@/stores/products'
 
 export async function loadProducts() {

--- a/docs/faq/unique-element-ids.md
+++ b/docs/faq/unique-element-ids.md
@@ -10,7 +10,7 @@ In many cases, it's sufficient to use a simple counter to generate a suitable `i
 
 Put something like this in a `.js` file:
 
-```js
+```js [utils/id.js]
 let count = 0
 
 export function newId(prefix = 'id-') {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "devDependencies": {
     "rimraf": "^6.0.1",
-    "vitepress": "^1.4.3"
+    "vitepress": "^1.4.3",
+    "vitepress-plugin-group-icons": "^1.3.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       vitepress:
         specifier: ^1.4.3
         version: 1.4.3(@algolia/client-search@4.24.0)(postcss@8.4.47)(search-insights@2.17.2)
+      vitepress-plugin-group-icons:
+        specifier: ^1.3.3
+        version: 1.3.3
 
 packages:
 
@@ -81,6 +84,12 @@ packages:
 
   '@algolia/transporter@4.24.0':
     resolution: {integrity: sha512-86nI7w6NzWxd1Zp9q3413dRshDqAzSbsQjhcDhPIatEFiZrL1/TjnHL8S7jVKFePlIMzDsZWXAXwXzcok9c5oA==}
+
+  '@antfu/install-pkg@0.4.1':
+    resolution: {integrity: sha512-T7yB5QNG29afhWVkVq7XeIMBa5U/vs9mX69YqayXypPRmYzUmzwnYltplHmPtZ4HPCn+sQKeXW8I47wCbuBOjw==}
+
+  '@antfu/utils@0.7.10':
+    resolution: {integrity: sha512-+562v9k4aI80m1+VuMHehNJWLOFjBnXn3tdOitzD0il5b7smkSBal4+a3oKiQTbrwMmN/TBUMDvbdoWDehgOww==}
 
   '@babel/helper-string-parser@7.25.9':
     resolution: {integrity: sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==}
@@ -259,6 +268,18 @@ packages:
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
+
+  '@iconify-json/logos@1.2.4':
+    resolution: {integrity: sha512-XC4If5D/hbaZvUkTV8iaZuGlQCyG6CNOlaAaJaGa13V5QMYwYjgtKk3vPP8wz3wtTVNVEVk3LRx1fOJz+YnSMw==}
+
+  '@iconify-json/vscode-icons@1.2.10':
+    resolution: {integrity: sha512-qjp/j2RcHEZkesuAT6RP8BfcuHa+oERr7K1twfsulrIHrKZlpxxBeEyFm+3evZSAOgD+sjgU5CuTYS3RfCL+Pg==}
+
+  '@iconify/types@2.0.0':
+    resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
+
+  '@iconify/utils@2.2.1':
+    resolution: {integrity: sha512-0/7J7hk4PqXmxo5PDBDxmnecw5PxklZJfNjIVG9FM0mEfVrvfudS22rYWsqVk6gR3UJ/mSYS90X4R3znXnqfNA==}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -497,6 +518,11 @@ packages:
   '@vueuse/shared@11.2.0':
     resolution: {integrity: sha512-VxFjie0EanOudYSgMErxXfq6fo8vhr5ICI+BuE3I9FnX7ePllEsVrRQ7O6Q1TLgApeLuPKcHQxAXpP+KnlrJsg==}
 
+  acorn@8.14.0:
+    resolution: {integrity: sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   algoliasearch@4.24.0:
     resolution: {integrity: sha512-bf0QV/9jVejssFBmz2HQLxUadxk574t4iwjCKp5E7NBzwKkrDEhKPISIIjAU/p6K5qDx3qoeh4+26zWN1jmw3g==}
 
@@ -544,6 +570,9 @@ packages:
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
   copy-anything@3.0.5:
     resolution: {integrity: sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==}
     engines: {node: '>=12.13'}
@@ -554,6 +583,15 @@ packages:
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+
+  debug@4.4.0:
+    resolution: {integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -600,6 +638,10 @@ packages:
     engines: {node: 20 || >=22}
     hasBin: true
 
+  globals@15.14.0:
+    resolution: {integrity: sha512-OkToC372DtlQeje9/zHIo5CT8lRP/FUgEOKBEhU4e0abL7J7CD24fD9ohiLN5hagG/kWCYj4K5oaxxtj2Z0Dig==}
+    engines: {node: '>=18'}
+
   hast-util-to-html@9.0.3:
     resolution: {integrity: sha512-M17uBDzMJ9RPCqLMO92gNNUDuBSq10a25SDBI08iCCxmorf4Yy6sYHK57n9WAbRAAaU+DuR4W6GN9K4DFZesYg==}
 
@@ -626,6 +668,13 @@ packages:
   jackspeak@4.0.2:
     resolution: {integrity: sha512-bZsjR/iRjl1Nk1UkjGpAzLNfQtzuijhn2g+pbZb98HQ1Gk8vM9hfbxeMBP+M2/UUdwj0RqGG3mlvk2MsAqwvEw==}
     engines: {node: 20 || >=22}
+
+  kolorist@1.8.0:
+    resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
+
+  local-pkg@0.5.1:
+    resolution: {integrity: sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==}
+    engines: {node: '>=14'}
 
   lru-cache@11.0.1:
     resolution: {integrity: sha512-CgeuL5uom6j/ZVrg7G/+1IXqRY8JXX4Hghfy5YE0EhoYQWvndP1kufu58cmZLNIDKnRhZrXfdS9urVWx98AipQ==}
@@ -669,6 +718,12 @@ packages:
   mitt@3.0.1:
     resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
 
+  mlly@1.7.3:
+    resolution: {integrity: sha512-xUsx5n/mN0uQf4V548PKQ+YShA4/IW0KI1dZhrNrPCLG+xizETbHTkOa1f8/xut9JRPp8kQuMnz0oqwkTiLo/A==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
   nanoid@3.3.7:
     resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -680,6 +735,9 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
+  package-manager-detector@0.2.8:
+    resolution: {integrity: sha512-ts9KSdroZisdvKMWVAVCXiKqnqNfXz4+IbrBG8/BWx/TR5le+jfenvoBuIZ6UWM9nz47W7AbD9qYfAwfWMIwzA==}
+
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
@@ -688,11 +746,17 @@ packages:
     resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}
     engines: {node: 20 || >=22}
 
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
   perfect-debounce@1.0.0:
     resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  pkg-types@1.3.0:
+    resolution: {integrity: sha512-kS7yWjVFCkIw9hqdJBoMxDdzEngmkr5FXeWZZfQ6GoYacjVnsW6l2CcYW/0ThD0vF4LPJgVYnrg4d0uuhwYQbg==}
 
   postcss@8.4.47:
     resolution: {integrity: sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==}
@@ -775,8 +839,14 @@ packages:
   tabbable@6.2.0:
     resolution: {integrity: sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==}
 
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  ufo@1.5.4:
+    resolution: {integrity: sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ==}
 
   unist-util-is@6.0.0:
     resolution: {integrity: sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==}
@@ -829,6 +899,9 @@ packages:
         optional: true
       terser:
         optional: true
+
+  vitepress-plugin-group-icons@1.3.3:
+    resolution: {integrity: sha512-IcWMqwjyx/vC5+WUVDRnpAJgEEnHFiIatrmZ04YaigpXj+6G5LeXJusxzuhT6YQEDebS/QGUMRmoq3ITXvhwKg==}
 
   vitepress@1.4.3:
     resolution: {integrity: sha512-956c2K2Mr0ubY9bTc2lCJD3g0mgo0mARB1iJC/BqUt4s0AM8Wl60wSU4zbFnzV7X2miFK1XJDKzGZnuEN90umw==}
@@ -983,6 +1056,13 @@ snapshots:
       '@algolia/logger-common': 4.24.0
       '@algolia/requester-common': 4.24.0
 
+  '@antfu/install-pkg@0.4.1':
+    dependencies:
+      package-manager-detector: 0.2.8
+      tinyexec: 0.3.2
+
+  '@antfu/utils@0.7.10': {}
+
   '@babel/helper-string-parser@7.25.9': {}
 
   '@babel/helper-validator-identifier@7.25.9': {}
@@ -1088,6 +1168,29 @@ snapshots:
 
   '@esbuild/win32-x64@0.21.5':
     optional: true
+
+  '@iconify-json/logos@1.2.4':
+    dependencies:
+      '@iconify/types': 2.0.0
+
+  '@iconify-json/vscode-icons@1.2.10':
+    dependencies:
+      '@iconify/types': 2.0.0
+
+  '@iconify/types@2.0.0': {}
+
+  '@iconify/utils@2.2.1':
+    dependencies:
+      '@antfu/install-pkg': 0.4.1
+      '@antfu/utils': 0.7.10
+      '@iconify/types': 2.0.0
+      debug: 4.4.0
+      globals: 15.14.0
+      kolorist: 1.8.0
+      local-pkg: 0.5.1
+      mlly: 1.7.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -1317,6 +1420,8 @@ snapshots:
       - '@vue/composition-api'
       - vue
 
+  acorn@8.14.0: {}
+
   algoliasearch@4.24.0:
     dependencies:
       '@algolia/cache-browser-local-storage': 4.24.0
@@ -1367,6 +1472,8 @@ snapshots:
 
   comma-separated-tokens@2.0.3: {}
 
+  confbox@0.1.8: {}
+
   copy-anything@3.0.5:
     dependencies:
       is-what: 4.1.16
@@ -1378,6 +1485,10 @@ snapshots:
       which: 2.0.2
 
   csstype@3.1.3: {}
+
+  debug@4.4.0:
+    dependencies:
+      ms: 2.1.3
 
   dequal@2.0.3: {}
 
@@ -1442,6 +1553,8 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 2.0.0
 
+  globals@15.14.0: {}
+
   hast-util-to-html@9.0.3:
     dependencies:
       '@types/hast': 3.0.4
@@ -1473,6 +1586,13 @@ snapshots:
   jackspeak@4.0.2:
     dependencies:
       '@isaacs/cliui': 8.0.2
+
+  kolorist@1.8.0: {}
+
+  local-pkg@0.5.1:
+    dependencies:
+      mlly: 1.7.3
+      pkg-types: 1.3.0
 
   lru-cache@11.0.1: {}
 
@@ -1521,6 +1641,15 @@ snapshots:
 
   mitt@3.0.1: {}
 
+  mlly@1.7.3:
+    dependencies:
+      acorn: 8.14.0
+      pathe: 1.1.2
+      pkg-types: 1.3.0
+      ufo: 1.5.4
+
+  ms@2.1.3: {}
+
   nanoid@3.3.7: {}
 
   oniguruma-to-js@0.4.3:
@@ -1529,6 +1658,8 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
+  package-manager-detector@0.2.8: {}
+
   path-key@3.1.1: {}
 
   path-scurry@2.0.0:
@@ -1536,9 +1667,17 @@ snapshots:
       lru-cache: 11.0.1
       minipass: 7.1.2
 
+  pathe@1.1.2: {}
+
   perfect-debounce@1.0.0: {}
 
   picocolors@1.1.1: {}
+
+  pkg-types@1.3.0:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.7.3
+      pathe: 1.1.2
 
   postcss@8.4.47:
     dependencies:
@@ -1639,7 +1778,11 @@ snapshots:
 
   tabbable@6.2.0: {}
 
+  tinyexec@0.3.2: {}
+
   trim-lines@3.0.1: {}
+
+  ufo@1.5.4: {}
 
   unist-util-is@6.0.0:
     dependencies:
@@ -1681,6 +1824,14 @@ snapshots:
       rollup: 4.24.3
     optionalDependencies:
       fsevents: 2.3.3
+
+  vitepress-plugin-group-icons@1.3.3:
+    dependencies:
+      '@iconify-json/logos': 1.2.4
+      '@iconify-json/vscode-icons': 1.2.10
+      '@iconify/utils': 2.2.1
+    transitivePeerDependencies:
+      - supports-color
 
   vitepress@1.4.3(@algolia/client-search@4.24.0)(postcss@8.4.47)(search-insights@2.17.2):
     dependencies:


### PR DESCRIPTION
Add this plugin: <https://www.npmjs.com/package/vitepress-plugin-group-icons>.

The plugin allows code blocks to display a file name (similar to code groups). It also adds icons based on the file type.

This plugin is already being used in the documentation for VitePress and Vite.